### PR TITLE
Fix serialization issues

### DIFF
--- a/app/backend/controllers/HomeController.scala
+++ b/app/backend/controllers/HomeController.scala
@@ -3,9 +3,9 @@ package backend.controllers
 import javax.inject._
 
 import backend.models._
-import backend.models.Entity.EntityId
-import backend.models.Story.StoryId
-import backend.models.User.UserId
+import backend.models.EntityId
+import backend.models.StoryId
+import backend.models.UserId
 import common.models._
 import org.joda.time.DateTime
 import play.api.libs.json.Json

--- a/app/backend/models/Entity.scala
+++ b/app/backend/models/Entity.scala
@@ -1,9 +1,11 @@
 package backend.models
 
-import backend.models.Entity.EntityId
-import common.models.{Text, TextMultiline, Tag}
+import common.models.{Tag, Text, TextMultiline}
 import org.joda.time.DateTime
 import play.api.libs.json._
+
+trait EntityIdType
+case  class EntityId(override val value: String ) extends Id[EntityIdType](value)
 
 case class Entity(
   id: EntityId,
@@ -15,33 +17,9 @@ case class Entity(
   created: DateTime,
   updated: DateTime)
 object Entity {
-  trait EntityIdType
-  type EntityId = Id[EntityIdType]
-  val  EntityId = Id.apply[EntityIdType] _
 
-  //implicit val format = Json.format[Entity] // EntityId => No apply function found matching unapply parameters :(
-  implicit def jsonReads: Reads[Entity] = new Reads[Entity] {
-    def reads(json: JsValue): JsResult[Entity] = JsSuccess(Entity(
-      (json \ "id").as[EntityId],
-      (json \ "category").as[EntityCategory],
-      (json \ "name").as[Text],
-      (json \ "description").as[TextMultiline],
-      (json \ "tags").as[Seq[Tag]],
-      (json \ "archived").as[Boolean],
-      (json \ "created").as[DateTime],
-      (json \ "updated").as[DateTime]))
-  }
-  implicit def jsonWrites: Writes[Entity] = new Writes[Entity] {
-    def writes(entity: Entity): JsValue = Json.obj(
-      "id" -> entity.id,
-      "category" -> entity.category,
-      "name" -> entity.name,
-      "description" -> entity.description,
-      "tags" -> entity.tags,
-      "archived" -> entity.archived,
-      "created" -> entity.created,
-      "updated" -> entity.updated)
-  }
+  implicit val entityIdFormat = Json.format[EntityId]
+  implicit val entityFormat = Json.format[Entity]
 }
 
 sealed trait EntityCategory

--- a/app/backend/models/Id.scala
+++ b/app/backend/models/Id.scala
@@ -3,10 +3,10 @@ package backend.models
 import common.models.utils.TString
 import play.api.libs.json._
 
-case class Id[T](value: String) extends TString
+class Id[T](override val value: String) extends TString
 object Id {
   implicit def jsonReads[T]: Reads[Id[T]] = new Reads[Id[T]] {
-    def reads(json: JsValue): JsResult[Id[T]] = json.asOpt[String].map(v => JsSuccess(Id[T](v))).getOrElse(JsError(s"String expected (actual: $json)"))
+    def reads(json: JsValue): JsResult[Id[T]] = json.asOpt[String].map(v => JsSuccess(new Id[T](v))).getOrElse(JsError(s"String expected (actual: $json)"))
   }
   implicit def jsonWrites[T]: Writes[Id[T]] = new Writes[Id[T]] {
     def writes(id: Id[T]): JsValue = JsString(id.value)

--- a/app/backend/models/Story.scala
+++ b/app/backend/models/Story.scala
@@ -1,8 +1,6 @@
 package backend.models
 
-import backend.models.Entity.EntityId
-import backend.models.Story.StoryId
-import common.models.{TextMultiline, Text, Tag}
+import common.models.{Tag, Text, TextMultiline}
 import org.joda.time.DateTime
 import play.api.libs.json._
 
@@ -11,20 +9,14 @@ case class StoryEntity(
   category: EntityCategory,
   label: Text)
 object StoryEntity {
-  //implicit val format = Json.format[StoryEntity] // EntityId => No apply function found matching unapply parameters :(
-  implicit def jsonReads: Reads[StoryEntity] = new Reads[StoryEntity] {
-    def reads(json: JsValue): JsResult[StoryEntity] = JsSuccess(StoryEntity(
-      (json \ "id").as[EntityId],
-      (json \ "category").as[EntityCategory],
-      (json \ "label").as[Text]))
-  }
-  implicit def jsonWrites: Writes[StoryEntity] = new Writes[StoryEntity] {
-    def writes(storyEntity: StoryEntity): JsValue = Json.obj(
-      "id" -> storyEntity.id,
-      "category" -> storyEntity.category,
-      "label" -> storyEntity.label)
-  }
+  import Entity.entityIdFormat
+  implicit val  storyEntityFormat = Json.format[StoryEntity]
 }
+
+
+trait StoryIdType
+
+case class StoryId(override val value : String) extends Id[StoryIdType](value)
 case class Story(
   id: StoryId,
   title: Text,
@@ -36,33 +28,7 @@ case class Story(
   created: DateTime,
   updated: DateTime)
 object Story {
-  trait StoryIdType
-  type StoryId = Id[StoryIdType]
-  val  StoryId = Id.apply[StoryIdType] _
 
-  //implicit val format = Json.format[Story] // EntityId => No apply function found matching unapply parameters :(
-  implicit def jsonReads: Reads[Story] = new Reads[Story] {
-    def reads(json: JsValue): JsResult[Story] = JsSuccess(Story(
-      (json \ "id").as[StoryId],
-      (json \ "title").as[Text],
-      (json \ "text").as[TextMultiline],
-      (json \ "date").as[DateTime],
-      (json \ "tags").as[Seq[Tag]],
-      (json \ "entities").as[Seq[StoryEntity]],
-      (json \ "archived").as[Boolean],
-      (json \ "created").as[DateTime],
-      (json \ "updated").as[DateTime]))
-  }
-  implicit def jsonWrites: Writes[Story] = new Writes[Story] {
-    def writes(story: Story): JsValue = Json.obj(
-      "id" -> story.id,
-      "title" -> story.title,
-      "text" -> story.text,
-      "date" -> story.date,
-      "tags" -> story.tags,
-      "entities" -> story.entities,
-      "archived" -> story.archived,
-      "created" -> story.created,
-      "updated" -> story.updated)
-  }
+  implicit val storyIdFormat = Json.format[StoryId]
+  implicit val storyFormat = Json.format[Story]
 }

--- a/app/backend/models/User.scala
+++ b/app/backend/models/User.scala
@@ -1,8 +1,11 @@
 package backend.models
 
-import backend.models.User.UserId
 import common.models.Email
 import play.api.libs.json._
+
+
+trait UserIdType
+case class UserId(override val value: String) extends Id[UserIdType](value)
 
 case class User(
   id: UserId,
@@ -10,11 +13,9 @@ case class User(
   lastName: String,
   email: Email)
 object User {
-  trait UserIdType
-  type UserId = Id[UserIdType]
-  val  UserId = Id.apply[UserIdType] _
 
-  //implicit val format = Json.format[User] // UserId => No apply function found matching unapply parameters :(
+  implicit val userIdFormat = Json.format[UserId]
+  implicit val format = Json.format[User] // UserId => No apply function found matching unapply parameters :(
   implicit def jsonReads: Reads[User] = new Reads[User] {
     def reads(json: JsValue): JsResult[User] = JsSuccess(User(
       (json \ "id").as[UserId],


### PR DESCRIPTION
En gros, tu as besoin que tes types soient des case classes (ou au moins que tu aies un `apply` et un `unapply` "corrects" pour ces types. Du coup ta solution à base d'aliases de types ne pouvait pas fonctionner avec `Json.format` 
